### PR TITLE
allow gsuite-api crate to be compiled on stable

### DIFF
--- a/google/admin/src/lib.rs
+++ b/google/admin/src/lib.rs
@@ -100,7 +100,6 @@
 //!     access_token = google admin.refresh_access_token().await.unwrap();
 //! }
 //! ```
-#![feature(async_stream)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::nonstandard_macro_braces)]
 #![allow(clippy::large_enum_variant)]


### PR DESCRIPTION
The `gsuite-api` crate is using `#[!feature(async_stream)]`. This prevents it from being compiled on stable Rust. 

It seems, that it does not actually need the feature turned on to compile. I assume, there was some copy&pasting going on here?